### PR TITLE
feat: add global exception handler and generic ApiResponse wrapper

### DIFF
--- a/server/src/main/java/com/express/inventory/dto/ApiResponse.java
+++ b/server/src/main/java/com/express/inventory/dto/ApiResponse.java
@@ -1,0 +1,125 @@
+package com.express.inventory.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+/**
+ * Standard API response wrapper used for all REST endpoints.
+ * 
+ * <p>
+ * This class provides a consistent response structure for both successful and
+ * failed API requests. It ensures that all responses contain metadata such as
+ * timestamps, HTTP status codes, request path, and optional payload or
+ * validation errors.
+ * </p>
+ * 
+ * <p>
+ * Example structure:
+ * </p>
+ * 
+ * <pre>
+ * {
+ *     "timestamp": "2026-03-14T23:55:10Z",
+ *     "status": 200,
+ *     "success": true,
+ *     "error": null,
+ *     "message": "Service is healthy",
+ *     "path": "/api/v1/health",
+ *     "data": {
+ *         "status": "UP",
+ *         "uptime": "12 hours 34 minutes",
+ *         "version": "1.0.0"
+ *     },
+ *     "fieldErrors": null
+ * }
+ * </pre>
+ * 
+ * @param <T> The type of response payload returned by the API.
+ */
+public record ApiResponse<T>(
+        Instant timestamp,
+        int status,
+        boolean success,
+        String error,
+        String message,
+        String path,
+        T data,
+        List<FieldError> fieldErrors) {
+
+    /**
+     * Creates a successful API response.
+     * 
+     * <p>
+     * This method should be used when an API completes successfully and returns
+     * data.
+     * </p>
+     * 
+     * @param <T>            The type of the response payload.
+     * @param status         The HTTP status of the response.
+     * @param servletRequest The HTTP request used to extract the request path.
+     * @param message        A human-readable message describing the result.
+     * @param data           The response payload returned by the API.
+     * @return A populated {@code ApiResponse} representing a successful request
+     */
+    public static <T> ApiResponse<T> success(
+            HttpStatus status,
+            String message,
+            T data) {
+
+        String path = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .build()
+                .getPath();
+
+        return new ApiResponse<T>(
+                Instant.now(),
+                status.value(),
+                true,
+                null,
+                message,
+                path,
+                data,
+                null);
+    }
+
+    /**
+     * Creates an error API response.
+     * 
+     * <p>
+     * This method should be used when a request fails due to validation errors,
+     * exceptions, or other server-side issues.
+     * </p>
+     * 
+     * @param <T>            The generic response type (Typically unused for errors)
+     * @param status         The HTTP status representing the failure.
+     * @param servletRequest The HTTP request used to extract the request path
+     * @param message        A human-readable description of the error.
+     * @param fieldErrors    A map containing field-specific validation errors where
+     *                       the key is the field name and the value is the error
+     *                       message.
+     * @return A populated {@code ApiResponse} representing a failed request
+     */
+    public static <T> ApiResponse<T> error(
+            HttpStatus status,
+            String message,
+            List<FieldError> fieldErrors) {
+
+        String path = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .build()
+                .getPath();
+
+        return new ApiResponse<T>(
+                Instant.now(),
+                status.value(),
+                false,
+                status.getReasonPhrase(),
+                message,
+                path,
+                null,
+                fieldErrors);
+    }
+}

--- a/server/src/main/java/com/express/inventory/dto/FieldError.java
+++ b/server/src/main/java/com/express/inventory/dto/FieldError.java
@@ -1,0 +1,7 @@
+package com.express.inventory.dto;
+
+public record FieldError(
+        String field,
+        String message) {
+
+}

--- a/server/src/main/java/com/express/inventory/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/express/inventory/exception/GlobalExceptionHandler.java
@@ -1,0 +1,101 @@
+package com.express.inventory.exception;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.express.inventory.dto.ApiResponse;
+import com.express.inventory.dto.FieldError;
+
+/**
+ * Global exception handler for the application.
+ * 
+ * <p>
+ * This class centralizes exception handling across all REST controllers and
+ * converts thrown exceptions into standardized {@link ApiResponse} structure.
+ * Using a global handler ensures consistent error responses throughout the API.
+ * </p>
+ * 
+ * <p>
+ * Handled exceptions include:
+ * </p>
+ * 
+ * <ul>
+ * <li>{@link RuntimeException} - fallback handler for unexpected server
+ * errors.</li>
+ * <li>{@link MethodArgumentNotValidException} - triggered when request body
+ * validation fails.</li>
+ * </ul>
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * Handles unexpected runtime exceptions.
+     * 
+     * <p>
+     * This serves as a fallback error for uncaught exceptions occuring within the
+     * application. It returns a generic {@code 500 Internal Server Error} response.
+     * </p>
+     * 
+     * @param ex The thrown runtime exception.
+     * @return a {@link ResponseEntity} containing a standardized
+     *         {@link ApiResponse} describing the error.
+     */
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<?> handleRunTime(RuntimeException ex) {
+        return createResponse(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage(), null);
+    }
+
+    /**
+     * Handles validation errors triggered by {@code @Valid} annotated request
+     * bodies.
+     * 
+     * <p>
+     * This exception is thrown by Spring when request body validation fails. Each
+     * validation error is extracted and mapped into a {@link FieldError} object
+     * which is returned to the client.
+     * </p>
+     * 
+     * @param ex The validation exception containing field error details.
+     * @return a {@link ResponseEntity} containing a {@link ApiResponse} with
+     *         validation error information.
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        List<FieldError> fieldErrors = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(e -> new FieldError(e.getField(), e.getDefaultMessage()))
+                .toList();
+
+        return createResponse(HttpStatus.BAD_REQUEST, "Validation failed", fieldErrors);
+    }
+
+    /**
+     * Helper method used to construct standardized API error responses.
+     * 
+     * <p>
+     * This method centralizes the logic for building {@link ApiResponse} objects
+     * and wrapping them in a {@link ResponseEntity} with the appropriate HTTP
+     * status code.
+     * </p>
+     * 
+     * @param status      The HTTP status to return.
+     * @param message     A human-readable description of the error.
+     * @param fieldErrors A list of validation errors, or {@code null} if none
+     *                    exist.
+     * @return A {@link ResponseEntity} containing the formatted
+     *         {@link ApiResponse}.
+     */
+    private ResponseEntity<ApiResponse<Void>> createResponse(
+            HttpStatus status,
+            String message,
+            List<FieldError> fieldErrors) {
+        return ResponseEntity.status(status).body(ApiResponse.error(status, message, fieldErrors));
+    }
+}


### PR DESCRIPTION
This PR introduces a centralized global exception handling system for the API. It includes:

- A GlobalExceptionHandler annotated with @RestControllerAdvice
- Handles RuntimeException for unexpected errors
- Handles MethodArgumentNotValidException for request body validation errors
- A generic ApiResponse<T> wrapper for standardized API responses
- Provides success and error static methods
- Includes timestamp, status, message, path, data, and fieldErrors
- A FieldError DTO to return validation error details in a clean, frontend-friendly format

Why this change is useful:

- Centralizes error handling in one place
- Standardizes response format for both success and error cases
- Makes validation errors readable and consistent for clients